### PR TITLE
wvp v2.2 -> stop...

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -17,15 +17,10 @@
         background-color: #377dff;
         height: 1rem;
       }
-
-      br {
-        display: block;
-        margin: 10px 0;
-      }
-
     </style>
     <!-- IIFE -->
     <script src="node_modules/@picovoice/web-voice-processor/dist/iife/index.js"></script>
+    <script src="node_modules/wavefile/dist/wavefile.js"></script>
     <script type="application/javascript">
       var handle;
 
@@ -75,14 +70,18 @@
           downloadLink.style.visibility = 'hidden';
 
           blobPromise.then(blob => {
-            var blobUrl = window.URL.createObjectURL(blob);
-            downloadLink.href = blobUrl;
-            writeMessage(
-              'Audio dump complete. Click to download the PCM binary data.',
-            );
-            document.getElementById('start-audio-dump').disabled = false;
+            let wav = new wavefile.WaveFile()
+            blob.arrayBuffer().then(data => {
+              const dataInt16Array = new Int16Array(data)
+              wav.fromScratch(1, 16000, "16", dataInt16Array)
+              downloadLink.href = wav.toDataURI();
+              writeMessage(
+                      'Audio dump complete. Click to download the PCM binary data.',
+              );
+              document.getElementById('start-audio-dump').disabled = false;
 
-            downloadLink.style.visibility = 'visible';
+              downloadLink.style.visibility = 'visible';
+            })
           });
         };
 
@@ -130,10 +129,9 @@
     <button id="start" disabled>Start Recording</button>
     <button id="pause" >Pause Recording</button>
     <button id="resume"disabled>Resume Recording</button>
-    <br>
     <button id="start-audio-dump" disabled>Start Audio Dump (10s)</button>
-    <a href="#" style="visibility: hidden" download id="audio-download-link"
-      >Download raw PCM</a
+    <a href="#" style="visibility: hidden" download="recorded.wav" id="audio-download-link"
+      >Download PCM in wav format</a
     >
   </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -17,6 +17,12 @@
         background-color: #377dff;
         height: 1rem;
       }
+
+      br {
+        display: block;
+        margin: 10px 0;
+      }
+
     </style>
     <!-- IIFE -->
     <script src="node_modules/@picovoice/web-voice-processor/dist/iife/index.js"></script>
@@ -50,7 +56,7 @@
           'WebVoiceProcessor is initializing & awaiting the result of microphone permissions ...',
         );
 
-        window.WebVoiceProcessor.WebVoiceProcessor.init({ engines: [vuWorkerEngine] })
+        window.WebVoiceProcessor.WebVoiceProcessor.init({ engines: [vuWorkerEngine], start:true })
           .then(webvp => {
             handle = webvp;
             document.getElementById('start-audio-dump').disabled = false;
@@ -63,7 +69,7 @@
 
         document.getElementById('start-audio-dump').onclick = () => {
           writeMessage('Starting Audio dump ...');
-          var blobPromise = handle.audioDump(3000);
+          var blobPromise = handle.audioDump(10000);
           document.getElementById('start-audio-dump').disabled = true;
           var downloadLink = document.getElementById('audio-download-link');
           downloadLink.style.visibility = 'hidden';
@@ -79,6 +85,39 @@
             downloadLink.style.visibility = 'visible';
           });
         };
+
+        document.getElementById('start').onclick = () => {
+          document.getElementById('start').disabled = true;
+          writeMessage('Starting ...');
+          handle.start();
+          document.getElementById('stop').disabled = false;
+          document.getElementById('pause').disabled = false;
+          document.getElementById('resume').disabled = true;
+        };
+
+        document.getElementById('stop').onclick = () => {
+          document.getElementById('stop').disabled = true;
+          writeMessage('Stoping ...');
+          handle.stop();
+          document.getElementById('start').disabled = false;
+          document.getElementById('pause').disabled = true;
+          document.getElementById('resume').disabled = true;
+        };
+
+        document.getElementById('resume').onclick = () => {
+          document.getElementById('resume').disabled = true;
+          writeMessage('Resuming ...');
+          handle.resume();
+          document.getElementById('pause').disabled = false;
+        };
+
+        document.getElementById('pause').onclick = () => {
+          document.getElementById('pause').disabled = true;
+          writeMessage('Pausing ...');
+          handle.pause();
+          document.getElementById('resume').disabled = false;
+        };
+
       });
     </script>
   </head>
@@ -87,7 +126,12 @@
     <div id="vu-meter">
       <div id="audio-rms-level">&nbsp;</div>
     </div>
-    <button id="start-audio-dump" disabled>Start Audio Dump (3s)</button>
+    <button id="stop" >Stop Recording</button>
+    <button id="start" disabled>Start Recording</button>
+    <button id="pause" >Pause Recording</button>
+    <button id="resume"disabled>Resume Recording</button>
+    <br>
+    <button id="start-audio-dump" disabled>Start Audio Dump (10s)</button>
     <a href="#" style="visibility: hidden" download id="audio-download-link"
       >Download raw PCM</a
     >

--- a/demo/package.json
+++ b/demo/package.json
@@ -18,6 +18,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@picovoice/web-voice-processor": "file:../package",
-    "http-server": "^14.0.0"
+    "http-server": "^14.0.0",
+    "wavefile": "^11.0.0"
   }
 }

--- a/demo/package.json
+++ b/demo/package.json
@@ -17,7 +17,7 @@
   "author": "Picovoice Inc",
   "license": "Apache-2.0",
   "dependencies": {
-    "@picovoice/web-voice-processor": "^2.1.2",
+    "@picovoice/web-voice-processor": "file:../package",
     "http-server": "^14.0.0"
   }
 }

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@picovoice/web-voice-processor",
-  "version": "2.1.4",
+  "version": "2.2.0",
   "description": "Real-time audio processing for voice, in web browsers",
   "entry": "src/index.ts",
   "module": "dist/esm/index.js",

--- a/package/src/downsampler.ts
+++ b/package/src/downsampler.ts
@@ -9,10 +9,10 @@
     specific language governing permissions and limitations under the License.
 */
 
-import { DownsamplerInterface } from './worker_types';
-import { WASM_BASE64 } from './downsampler_b64';
-import { arrayBufferToStringAtIndex, base64ToUint8Array } from './utils';
-import { wasiSnapshotPreview1Emulator } from './wasi_snapshot';
+import {DownsamplerInterface} from './worker_types';
+import {WASM_BASE64} from './downsampler_b64';
+import {arrayBufferToStringAtIndex, base64ToUint8Array} from './utils';
+import {wasiSnapshotPreview1Emulator} from './wasi_snapshot';
 
 const PV_STATUS_SUCCESS = 10000;
 
@@ -86,7 +86,9 @@ class Downsampler implements DownsamplerInterface {
     order: number,
     frameLength: number,
   ): Promise<DownsamplerWasmOutput> {
-    const memory = new WebAssembly.Memory({ initial: 100, maximum: 100 });
+    // A WebAssembly page has a constant size of 64KiB. -> 4MiB ~= 64 pages
+    // minimum memory requirements for init: 2 pages
+    const memory = new WebAssembly.Memory({initial: 64, maximum: 128});
 
     const memoryBufferUint8 = new Uint8Array(memory.buffer);
 
@@ -120,18 +122,15 @@ class Downsampler implements DownsamplerInterface {
     };
 
     const wasmCodeArray = base64ToUint8Array(WASM_BASE64);
-    const { instance } = await WebAssembly.instantiate(
+    const {instance} = await WebAssembly.instantiate(
       wasmCodeArray,
       importObject,
     );
 
     const alignedAlloc = instance.exports.aligned_alloc as CallableFunction;
-    const pvDownsamplerInit = instance.exports
-      .pv_downsampler_init as CallableFunction;
-    const pvDownsamplerConvertNumSamplesToInputSampleRate = instance.exports
-      .pv_downsampler_convert_num_samples_to_input_sample_rate as CallableFunction;
-    const pvDownsamplerVersion = instance.exports
-      .pv_downsampler_version as CallableFunction;
+    const pvDownsamplerInit = instance.exports.pv_downsampler_init as CallableFunction;
+    const pvDownsamplerConvertNumSamplesToInputSampleRate = instance.exports.pv_downsampler_convert_num_samples_to_input_sample_rate as CallableFunction;
+    const pvDownsamplerVersion = instance.exports.pv_downsampler_version as CallableFunction;
 
     const objectAddressAddress = alignedAlloc(
       Int32Array.BYTES_PER_ELEMENT,
@@ -179,7 +178,7 @@ class Downsampler implements DownsamplerInterface {
     }
 
     const pvDownsamplerReset = instance.exports
-      .pvDownsamplerReset as CallableFunction;
+      .pv_downsampler_reset as CallableFunction;
     const pvDownsamplerProcess = instance.exports
       .pv_downsampler_process as CallableFunction;
     const pvDownsamplerDelete = instance.exports
@@ -192,7 +191,7 @@ class Downsampler implements DownsamplerInterface {
       objectAddress: objectAddress,
       outputBufferAddress: outputBufferAddress,
       pvDownsamplerConvertNumSamplesToInputSampleRate:
-        pvDownsamplerConvertNumSamplesToInputSampleRate,
+      pvDownsamplerConvertNumSamplesToInputSampleRate,
       pvDownsamplerInit: pvDownsamplerInit,
       pvDownsamplerProcess: pvDownsamplerProcess,
       pvDownsamplerReset: pvDownsamplerReset,

--- a/package/src/downsampler.ts
+++ b/package/src/downsampler.ts
@@ -164,7 +164,7 @@ class Downsampler implements DownsamplerInterface {
     );
     const inputBufferAddress = alignedAlloc(
       Int16Array.BYTES_PER_ELEMENT,
-      inputframeLength * Int16Array.BYTES_PER_ELEMENT,
+      (inputframeLength+1) * Int16Array.BYTES_PER_ELEMENT,
     );
     if (inputBufferAddress === 0) {
       throw new Error('malloc failed: Cannot allocate memory');

--- a/package/src/downsampling_worker.ts
+++ b/package/src/downsampling_worker.ts
@@ -109,7 +109,8 @@ function processAudio(inputFrame: Float32Array): void {
   _oldInputBuffer = new Int16Array([]);
 
   while (inputBufferExtended.length > 0) {
-    const numInputSamples = _downsampler.getNumRequiredInputSamples(_outputframeLength);
+    // +1 is for the extra needed sample for the interpolation
+    const numInputSamples = _downsampler.getNumRequiredInputSamples(_outputframeLength) + 1;
     if (numInputSamples > inputBufferExtended.length) {
       _oldInputBuffer = new Int16Array(inputBufferExtended.length);
       _oldInputBuffer.set(inputBufferExtended);

--- a/package/src/downsampling_worker.ts
+++ b/package/src/downsampling_worker.ts
@@ -9,7 +9,7 @@
     specific language governing permissions and limitations under the License.
 */
 
-import { DownsamplingWorkerRequest } from './worker_types';
+import {DownsamplingWorkerRequest} from './worker_types';
 
 import Downsampler from './downsampler';
 
@@ -109,8 +109,7 @@ function processAudio(inputFrame: Float32Array): void {
   _oldInputBuffer = new Int16Array([]);
 
   while (inputBufferExtended.length > 0) {
-    const numInputSamples =
-      _downsampler.getNumRequiredInputSamples(_outputframeLength);
+    const numInputSamples = _downsampler.getNumRequiredInputSamples(_outputframeLength);
     if (numInputSamples > inputBufferExtended.length) {
       _oldInputBuffer = new Int16Array(inputBufferExtended.length);
       _oldInputBuffer.set(inputBufferExtended);
@@ -165,6 +164,10 @@ function reset(): void {
   _oldInputBuffer = new Int16Array([]);
 }
 
+function release(): void {
+  _downsampler.delete();
+}
+
 onmessage = function (event: MessageEvent<DownsamplingWorkerRequest>): void {
   switch (event.data.command) {
     case 'init':
@@ -179,6 +182,9 @@ onmessage = function (event: MessageEvent<DownsamplingWorkerRequest>): void {
       break;
     case 'reset':
       reset();
+      break;
+    case 'release':
+      release();
       break;
     case 'start_audio_dump':
       startAudioDump(event.data.durationMs);

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,2 +1,2 @@
-export { WebVoiceProcessor } from './web_voice_processor';
-export { browserCompatibilityCheck } from './utils';
+export {WebVoiceProcessor} from './web_voice_processor';
+export {browserCompatibilityCheck} from './utils';

--- a/package/src/utils.ts
+++ b/package/src/utils.ts
@@ -62,20 +62,20 @@ export function browserCompatibilityCheck(): BrowserFeatures {
  * Convert a null terminated phrase stored inside an array buffer to a string
  *
  * @param arrayBuffer input array buffer
- * @param index the index at which the phrase is stored
+ * @param indexStart the index at which the phrase is stored
  * @return retrieved string
  */
 
 export function arrayBufferToStringAtIndex(
   arrayBuffer: Uint8Array,
-  index: number,
+  indexStart: number,
 ): string {
-  let stringBuffer = '';
-  let indexBuffer = index;
-  while (arrayBuffer[indexBuffer] === 0) {
-    stringBuffer += String.fromCharCode(arrayBuffer[indexBuffer++]);
+  let indexEnd = indexStart;
+  while (arrayBuffer[indexEnd] !== 0) {
+    indexEnd++;
   }
-  return stringBuffer;
+  const utf8decoder = new TextDecoder('utf-8');
+  return utf8decoder.decode(arrayBuffer.subarray(indexStart, indexEnd));
 }
 
 /**

--- a/package/src/web_voice_processor.ts
+++ b/package/src/web_voice_processor.ts
@@ -229,6 +229,7 @@ export class WebVoiceProcessor {
   public async start(): Promise<void> {
     if (this._isReleased) {
       this._isReleased = false;
+      this._isRecording = true;
       const [microphoneStream, audioContext, audioSource, downsamplingWorker] = await WebVoiceProcessor._initMic(this._options)
 
       this._mediaStream = microphoneStream;

--- a/package/src/web_voice_processor.ts
+++ b/package/src/web_voice_processor.ts
@@ -59,8 +59,6 @@ export class WebVoiceProcessor {
       window.webkitAudioContext)();
     const audioSource = audioContext.createMediaStreamSource(microphoneStream);
 
-    console.log(audioSource.context.sampleRate)
-
     const downsamplingWorker = await DownsamplerWorkerFactory.create(
       audioSource.context.sampleRate,
       options.outputSampleRate,

--- a/package/src/web_voice_processor.ts
+++ b/package/src/web_voice_processor.ts
@@ -1,5 +1,5 @@
 /*
-    Copyright 2018-2021 Picovoice Inc.
+    Copyright 2018-2022 Picovoice Inc.
 
     You may not use this file except in compliance with the license. A copy of the license is located in the "LICENSE"
     file accompanying this source.
@@ -9,7 +9,7 @@
     specific language governing permissions and limitations under the License.
 */
 
-import { DownsamplingWorker, DownsamplingWorkerResponse } from './worker_types';
+import {DownsamplingWorker, DownsamplingWorkerResponse} from './worker_types';
 import DownsamplerWorkerFactory from './downsampler_worker_factory';
 
 export type WebVoiceProcessorOptions = {
@@ -32,28 +32,21 @@ export type WebVoiceProcessorOptions = {
  */
 export class WebVoiceProcessor {
   private _audioContext: AudioContext;
+  private _audioDumpPromise: Promise<Blob> | null = null;
+  private _audioDumpReject: any = null;
+  private _audioDumpResolve: any = null;
   private _audioSource: MediaStreamAudioSourceNode;
-  private _mediaStream: MediaStream;
   private _downsamplingWorker: DownsamplingWorker;
   private _engines: Array<Worker>;
   private _isRecording: boolean;
   private _isReleased = false;
-  private _audioDumpPromise: Promise<Blob> | null = null;
-  private _audioDumpResolve: any = null;
-  private _audioDumpReject: any = null;
+  private _mediaStream: MediaStream;
+  private _options: WebVoiceProcessorOptions;
 
-  /**
-   * Acquires the microphone audio stream (incl. asking permission),
-   * and continuously forwards the downsampled audio to speech recognition worker engines.
-   *
-   * @param options Startup options including whether to immediately begin
-   * processing, and the set of voice processing engines
-   * @return the promise from mediaDevices.getUserMedia()
-   */
-
-  public static async init(
+  private static async _initMic(
     options: WebVoiceProcessorOptions,
-  ): Promise<WebVoiceProcessor> {
+  ): Promise<any> {
+
     // Get microphone access and ask user permission
     const microphoneStream = await navigator.mediaDevices.getUserMedia({
       audio: {
@@ -66,57 +59,38 @@ export class WebVoiceProcessor {
       window.webkitAudioContext)();
     const audioSource = audioContext.createMediaStreamSource(microphoneStream);
 
+    console.log(audioSource.context.sampleRate)
+
     const downsamplingWorker = await DownsamplerWorkerFactory.create(
       audioSource.context.sampleRate,
       options.outputSampleRate,
       options.frameLength,
     );
 
-    return new WebVoiceProcessor(
+    return [
       microphoneStream,
       audioContext,
       audioSource,
       downsamplingWorker,
-      options,
-    );
+    ]
   }
 
-  private constructor(
-    inputMediaStream: MediaStream,
-    audioContext: AudioContext,
-    audioSource: MediaStreamAudioSourceNode,
-    downsamplingWorker: DownsamplingWorker,
-    options: WebVoiceProcessorOptions,
-  ) {
-    this._mediaStream = inputMediaStream;
+  private async _setupAudio(): Promise<any> {
 
-    if (options.engines === undefined) {
-      this._engines = [];
-    } else {
-      this._engines = options.engines;
-    }
-    this._isRecording = options.start ?? true;
-
-    this._downsamplingWorker = downsamplingWorker;
-    this._audioContext = audioContext;
-    this._audioSource = audioSource;
-
-    const node = audioContext.createScriptProcessor(4096, 1, 1);
+    const node = this._audioContext.createScriptProcessor(4096, 1, 1);
     node.onaudioprocess = (event: AudioProcessingEvent): void => {
-      if (!this._isRecording) {
-        return;
+      if (this._isRecording) {
+        this._downsamplingWorker.postMessage({
+          command: 'process',
+          inputFrame: event.inputBuffer.getChannelData(0),
+        });
       }
-
-      downsamplingWorker.postMessage({
-        command: 'process',
-        inputFrame: event.inputBuffer.getChannelData(0),
-      });
     };
 
     this._audioSource.connect(node);
     node.connect(this._audioContext.destination);
 
-    downsamplingWorker.onmessage = (
+    this._downsamplingWorker.onmessage = (
       event: MessageEvent<DownsamplingWorkerResponse>,
     ): void => {
       switch (event.data.command) {
@@ -142,6 +116,55 @@ export class WebVoiceProcessor {
         }
       }
     };
+  }
+
+  /**
+   * Acquires the microphone audio stream (incl. asking permission),
+   * and continuously forwards the downsampled audio to speech recognition worker engines.
+   *
+   * @param options Startup options including whether to immediately begin
+   * processing, and the set of voice processing engines
+   * @return the promise from mediaDevices.getUserMedia()
+   */
+
+  public static async init(
+    options: WebVoiceProcessorOptions,
+  ): Promise<WebVoiceProcessor> {
+
+    const [microphoneStream, audioContext, audioSource, downsamplingWorker] = await this._initMic(options)
+
+    return new WebVoiceProcessor(
+      microphoneStream,
+      audioContext,
+      audioSource,
+      downsamplingWorker,
+      options,
+    );
+  }
+
+  private constructor(
+    inputMediaStream: MediaStream,
+    audioContext: AudioContext,
+    audioSource: MediaStreamAudioSourceNode,
+    downsamplingWorker: DownsamplingWorker,
+    options: WebVoiceProcessorOptions,
+  ) {
+    this._options = options;
+
+    if (options.engines === undefined) {
+      this._engines = [];
+    } else {
+      this._engines = options.engines;
+    }
+    this._isRecording = options.start ?? true;
+
+    this._mediaStream = inputMediaStream;
+    this._downsamplingWorker = downsamplingWorker;
+    this._audioContext = audioContext;
+    this._audioSource = audioSource;
+
+    this._setupAudio();
+
   }
 
   /**
@@ -179,30 +202,45 @@ export class WebVoiceProcessor {
     if (!this._isReleased) {
       this._isReleased = true;
       this._isRecording = false;
-      this._downsamplingWorker.postMessage({ command: 'reset' });
+      this._downsamplingWorker.postMessage({command: 'release'});
       this._downsamplingWorker.terminate();
 
-      for (const track of this._mediaStream.getTracks()) {
+      this._mediaStream.getTracks().forEach(function(track) {
         track.stop();
-      }
+      });
 
       await this._audioContext.close();
     }
   }
 
-  public start(): void {
-    this._isRecording = true;
+  public async stop(): Promise<void> {
+    return this.release()
   }
 
   public pause(): void {
     this._isRecording = false;
+    this._downsamplingWorker.postMessage({command: 'reset'});
   }
 
   public resume(): void {
     this._isRecording = true;
   }
 
-  get audioContext(): AudioContext {
+  public async start(): Promise<void> {
+    if (this._isReleased) {
+      this._isReleased = false;
+      const [microphoneStream, audioContext, audioSource, downsamplingWorker] = await WebVoiceProcessor._initMic(this._options)
+
+      this._mediaStream = microphoneStream;
+      this._downsamplingWorker = downsamplingWorker;
+      this._audioContext = audioContext;
+      this._audioSource = audioSource;
+
+      this._setupAudio();
+    }
+  }
+
+  get audioContext(): AudioContext | null {
     return this._audioContext;
   }
 


### PR DESCRIPTION
- brought back `pause` and `resume`, so now there are `stop/start` and `pause/resume` functionality.
  - `stop` basically kills everything, including the mic, so we need to init all components if we want to start again.
  -  'pause' is only cut the input from the downsampler so we get no output, but the mic is still listening.
- optimized the wasm memory usage
- fixed the issue with internal interpolation
- updated the demo to create a wav file for the dumped audio file