### PR TITLE
allow custom audio constraints.

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,8 @@ export type WebVoiceProcessorOptions = {
   filterOrder?: number;
   /** Custom made recorder processor */
   customRecorderProcessorURL?: string;
+  /** audio constraints for mediaDevices.getUserMedia */
+  audioConstraints?: MediaTrackConstraints;
 };
 
 export type ResamplerWorkerInitRequest = {

--- a/src/web_voice_processor.ts
+++ b/src/web_voice_processor.ts
@@ -320,15 +320,16 @@ export class WebVoiceProcessor {
       frameLength = 512,
       deviceId = null,
       filterOrder = 50,
+      audioConstraints = {}
     } = options;
     const numberOfChannels = 1;
 
     const audioContext = await this.getAudioContext();
 
-    // Get microphone access and ask user permission
     const microphoneStream = await navigator.mediaDevices.getUserMedia({
       audio: {
         deviceId: deviceId ? { exact: deviceId } : undefined,
+        ...audioConstraints,
       },
     });
 


### PR DESCRIPTION
Safari require set echoCancellation: false to avoid the volume down issue (together with navigator.audioSession.type = "play-and-record", but this can be done outside of this library).
So we have to allow custom the audio constraints here. maybe also resolve #45 